### PR TITLE
Fix `cluster_id` error

### DIFF
--- a/src/EMR_deploy_and_install_spot.py
+++ b/src/EMR_deploy_and_install_spot.py
@@ -8,6 +8,7 @@ import paramiko
 import re
 import os
 import yaml
+import json
 
 PATH=os.path.dirname(os.path.abspath(__file__))
 
@@ -19,8 +20,9 @@ command='aws emr create-cluster --applications Name=Hadoop Name=Spark --tags \'p
 print("\n\nYour AWS CLI export command:\n")
 print(command)
 
-cluster_id_json=os.popen(command).read()
-cluster_id=cluster_id_json.split(": \"",1)[1].split("\"\n")[0]
+response = os.popen(command).read()
+cluster_id_json = json.loads(response)
+cluster_id = cluster_id_json['ClusterId']
 
 # Gives EMR cluster information
 client_EMR = boto3.client('emr', region_name=c['config']['REGION'])


### PR DESCRIPTION
When running `sh cloudformation_hail_spot.sh`, I get the following error:

```
botocore.exceptions.ClientError: An error occurred (ValidationException) when calling the DescribeCluster operation: clusterId 'j-457E82HG77Y8",
    "ClusterArn": "arn:aws:elasticmapreduce:us-east-1:600446937575:cluster/j-457E82HG77Y8' is not valid.
```

This error is occurring because of incorrect string splitting in `.split(": \"",1)[1].split("\"\n")[0]`.

Luckily, the command `os.popen(command).read()` gives the following, as a string:

```json
{
    "ClusterId": "j-457E82HG77Y8",
    "ClusterArn": "arn:aws:elasticmapreduce:us-east-1:600446937575:cluster/j-457E82HG77Y8"
}
```

A more robust way to extract the `cluster_id` is to read this response into a Python dictionary using the `json` library.